### PR TITLE
Fix python typo

### DIFF
--- a/computer_data.package body.sql
+++ b/computer_data.package body.sql
@@ -123,7 +123,7 @@ begin
   mimetypes(3).c_category := 'Image';
   mimetypes(3).c_types := 'image/bmp,image/gif,image/x-icon,image/jpeg,image/png,image/x-tiff,image/tiff';
   mimetypes(4).c_category := 'Text';
-  mimetypes(4).c_types := 'text/html,text/asp,text/plain,text/css,text/x-script,text/x-java-source,text/javascript,text/x-script.perl,text/x-script.phyton,text/richtext,text/sgml,text/xml';
+  mimetypes(4).c_types := 'text/html,text/asp,text/plain,text/css,text/x-script,text/x-java-source,text/javascript,text/x-script.perl,text/x-script.python,text/richtext,text/sgml,text/xml';
   mimetypes(5).c_category := 'Application';
   mimetypes(5).c_types := 'application/octet-stream,application/postscript,application/octet-stream,application/x-binary,application/pkix-cert,application/java,application/x-x509-ca-cert,application/msword,application/x-gzip,application/javascript,application/pdf,application/mspowerpoint,application/x-compressed,application/excel';
   mimetypes(6).c_category := 'Multipart';


### PR DESCRIPTION
Was just trying one of your end points, and noticed the result came back as a typo.

![image](https://cloud.githubusercontent.com/assets/1747643/24835885/33c8429c-1d51-11e7-8522-6357b01d98b2.png)
